### PR TITLE
Create ECIP-1015

### DIFF
--- a/ECIPs/ECIP-1015.md
+++ b/ECIPs/ECIP-1015.md
@@ -1,0 +1,35 @@
+In reference to:
+ethereum/eip150
+
+Concerning: Long-term gas cost changes for IO-heavy operations to mitigate transaction spam attacks
+
+With the understanding that:
+
+1) This is a fork intended for protocol improvement.
+2) This is mutually beneficial to all etherem clients in order to mitigate current attacks.
+3) Ethcore and Ethereum Foundation intend to implement the changes in unison on or around block 2,463,000 
+4) an unknown number of ETC nodes are using --oppose-dao clients and will be switched to the EIP gas price model at block 2,463,000
+
+Issues to address:
+
+1) The need to avoid silverware drawer of ethereums:
+
+a. EF Official
+b. EF Official- no eip 150 fork
+c. EF TheDao Classic (accepted 1920k but ignored GasReprice, not upgraded nodes basically)
+d. ETC Early GasReprice, block 2,463,000 (uses upgraded EF version of geth with --oppose-dao flag)
+e. ETC Late GasReprice, block 2500000 (uses etc version 2.0.0 client)
+f. Ethereum Classic Classic (doomed) no forks ever from homestead
+
+2) Urgency - this needs to be ready for testing as soon as humanly possible.
+
+3) MAKE THE PLAN KNOWN. on all channels. smoke signals as need be.
+
+Proposed actions:
+0. MAKE KNOWN TO EVERYONE WHAT THE DECISION IS AND PUBLISH REQUIRED CHANGES IN ACCEPTED ECIP. 
+1. Incorporate EIP-150 as ECIP-1015, to follow our process
+2. Attempt to reach agreement with EF devs to either support etc flag forking on 2,500,000, or disable –oppose-dao-fork switch completely (absent that, an active campaign to get people to upgrade to classic geth)
+3. Get parity buy-in to make a new release supporting our HF (which would require a PR be submited for json config change)
+4. Implement ECIP-1015 on top of our 2.0.0 geth code base, test it
+5. Release new classic geth version, promote its usage heavily among ETC users, as well as with pools, exchanges, and wallets that support ETC
+7. Hard fork on block 2,500,000 ~2016-10-25


### PR DESCRIPTION
In reference to:
ethereum/eip150

Concerning: Long-term gas cost changes for IO-heavy operations to mitigate transaction spam attacks

With the understanding that:

1) This is a fork intended for protocol improvement.
2) This is mutually beneficial to all etherem clients in order to mitigate current attacks.
3) Ethcore and Ethereum Foundation intend to implement the changes in unison on or around block 2,463,000 
4) an unknown number of ETC nodes are using --oppose-dao clients and will be switched to the EIP gas price model at block 2,463,000

Issues to address:

1) The need to avoid silverware drawer of ethereums:

a. EF Official
b. EF Official- no eip 150 fork
c. EF TheDao Classic (accepted 1920k but ignored GasReprice, not upgraded nodes basically)
d. ETC Early GasReprice, block 2,463,000 (uses upgraded EF version of geth with --oppose-dao flag)
e. ETC Late GasReprice, block 2500000 (uses etc version 2.0.0 client)
f. Ethereum Classic Classic (doomed) no forks ever from homestead

2) Urgency - this needs to be ready for testing as soon as humanly possible.

3) MAKE THE PLAN KNOWN. on all channels. smoke signals as need be.

Proposed actions:
0. MAKE KNOWN TO EVERYONE WHAT THE DECISION IS AND PUBLISH REQUIRED CHANGES IN ACCEPTED ECIP. 
1. Incorporate EIP-150 as ECIP-1015, to follow our process
2. Attempt to reach agreement with EF devs to either support etc flag forking on 2,500,000, or disable –oppose-dao-fork switch completely (absent that, an active campaign to get people to upgrade to classic geth)
3. Get parity buy-in to make a new release supporting our HF (which would require a PR be submited for json config change)
4. Implement ECIP-1015 on top of our 2.0.0 geth code base, test it
5. Release new classic geth version, promote its usage heavily among ETC users, as well as with pools, exchanges, and wallets that support ETC
7. Hard fork on block 2,500,000 ~2016-10-25
