### PR TITLE
Removal of "Maintenance" Portion of the Proposal

### DIFF
--- a/ECIPs/ECIP-1017.md
+++ b/ECIPs/ECIP-1017.md
@@ -11,7 +11,7 @@
 
 ### Abstract
 
-This ECIP proposes a solution to the Ethereum Classic Monetary Policy to adjust, with finality, the current emission schedule implementation of 14.0625ETC per block in perpetuity. The solution proposed introduces a theoretical upper bound on the maximum absolute number of ETC and introduces a method of degraded emission over time. In addition, this ECIP describes the requirements associated with maintaining this emission schedule through a potential change of the network’s consensus algorithm, from its current Ethash based Proof of Work to a possible POS or POW/POS hybrid model.
+This ECIP proposes a solution to the Ethereum Classic Monetary Policy to adjust, with finality, the current emission schedule implementation of 14.0625ETC per block in perpetuity. The solution proposed introduces a theoretical upper bound on the maximum absolute number of ETC and introduces a method of degraded emission over time.
 
 <br />
 
@@ -43,7 +43,7 @@ The current mining rewards on the Ethereum Classic Network are as follows:
 
 * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles. 
 
-* A reward of 7/8 (4.375ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
+* A reward of up to 7/8 (4.375ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
 
 * This reward structure is set to continue in perpetuity.
 
@@ -65,7 +65,7 @@ The proposed mining rewards on the Ethereum Classic Network are as follows:
 
     * An extra reward to the winning miner for including uncles as part of the block, in the form of an extra 1/32 (0.15625ETC) per uncle included, up to a maximum of two (2) uncles. 
 
-    * A reward of 7/8 of the winning block reward (4.375ETC) for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
+    * A reward of up to 7/8 of the winning block reward (4.375ETC) for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
 
 * Era 2 (blocks 5,000,001 - 10,000,000)
 
@@ -75,7 +75,7 @@ The proposed mining rewards on the Ethereum Classic Network are as follows:
 
     * A reward of 1/32 (0.125ETC) of the winning block reward for a miner who has mined an uncled block and has that uncle included in the winning block by the winning miner, up to a maximum of two (2) uncles included in a winning block.
 
-    * Era 2 represents a reduction of 20% of Era 1 values, while also reducing uncle rewards to uncle miners to be the same as the reward to the winning miner for including the uncle(s).
+    * Era 2 represents a reduction of 20% of Era 1 values, while also reducing uncle rewards to uncle miners to be the same value as the reward to the winning miner for including the uncle(s).
 
 * Era 3+
 
@@ -83,32 +83,6 @@ The proposed mining rewards on the Ethereum Classic Network are as follows:
 
     * Every Era will last for 5,000,000 blocks. 
     
-<br />
-
-####Maintenance of the Economic Policy Through a Transition of the Network Consensus Algorithm
-
-Should the Ethereum Classic Network decide to change its consensus algorithm to a model other than the current Ethash based POW implementation, the following requirements will be adhered to ensure the finality of the implemented Monetary Policy:
-
-* Maintain a total network rate of emission no higher than the upper bound (block reward plus reward for two uncles included per block) rate of emission per block over time as adopted in the emission schedule for the current Ethash based POW algorithm. 
-
-* Maintain a total network rate of emission no lower than the lower bound (block reward only) rate of emission per block over time as adopted in the emission schedule for the current Ethash based POW algorithm.
-
-* Maintain a rate of emission that is equal to the Ethash based POW model of 15 second rewards over a no longer than 60 second period.
-
-For example, assume that the Ethereum Classic chooses to hard fork the blockchain at block 7,500,000 in order to introduce a new consensus algorithm, based on a POW/POS hybrid model. In this hypothetical scenario, the new algorithm enables blocks to be confirmed by POS nodes at 5 second intervals, 10 times per minute and POW blocks, consisting of the blocks produced by the POS nodes, at 1 min intervals. 
-
-The method by which the network chooses to award both POS and POW participants is beyond the scope of this explanation, but what is important to note is that the range in which the total award is allowed: 
-
-* Block 7,500,000 is in Era 2
-
-* The maximum reward/emission in Era 2 is 4.5 ETC every 15 seconds, assuming a the maximum of two uncles is included per block
-
-* The minimum reward/emission in Era 2 is 4.0 ETC every 15 seconds, assuming no uncles are included in the winning block.
-
-In the scenario where the network moves to a POW/POS hybrid model, the upper bound allowable to the new model, in terms of emission rate, is 4.5 ETC every 15 seconds or an equivalent rate produced no longer than every 60 seconds (18 ETC/min). The lower bound allowable to the new model, in terms of emission rate, is 4.0 ETC every 15 seconds, or an equivalent rate produced no longer than every 60 seconds (16 ETC/min).
-
-Additionally, an adjustment by this hybrid model is required to deprecate the rate of emission per Era of time. This Era of time is set at  the equivalent of the proposed emission rate of 5,000,000 blocks and assumes a time of 15s between blocks. So by the equivalent of block 10,000,000, the new model is to reduce its emission rate by 20%, and will continue this 20% every 5,000,000 blocks or equivalent in time, in perpetuity. 
-
 <br />
 
 ### Rationale
@@ -121,7 +95,7 @@ Why this 5M20 model:
 
 * Uncle inclusion rates through block 5M will likely remain at around the 5%. Because of this, once block 5M is reached, in the worst case scenario (supply wise, which assumes two uncles included every block in perpetuity) the total supply will not exceed 210.7M ETC. Should the network remain as efficient in its ability to propagate found blocks as it has in Era 1 (5.4% uncle rate), the total supply will not be less than 198.5M ETC. This provides for an incentive to miners and client developers to maintain high standards and maintenance of their hardware and software they introduce into the network.
 
-* The 5M model provides a balance between providing an acceptable depreciating distribution rate for rewarding high risk investment into the system, and maintaining an active supply production over time, maintaining a future supply rate and keeping that potential price of the ethereum token suppressed enough to ensure transaction prices can remain lower than if the supply were to reduce to zero at an earlier date. This serves as a "blow off valve" for price increase in the case that a dynamic gas model cannot be implemented for the foreseeable future. 
+* The 5M model provides a balance between providing an acceptable depreciating distribution rate for rewarding high risk investment into the system and maintaining an active supply production over time. Maintaining this future supply rate keeps the potential price of the ethereum token suppressed enough to ensure transaction prices can remain lower than if the supply were to reduce to zero at an earlier date. This serves as a "blow off valve" for price increases in the case that a dynamic gas model cannot be implemented for the foreseeable future. 
 
 * Having the monetary policy begin at 5M provides a balance between delaying the implementation to provide enough time for code development and testing, and accelerating the implementation to provide an incentive to potential early adopters and high risk investors. Based on community discussion, beginning before block 4M is too soon for development, testing, and implementation of the policy, and later than block 6M is too long to interest many potential early adopters/investors. 
 
@@ -131,7 +105,7 @@ Why this 5M20 model:
 
 * Because the rate at which uncled blocks can vary with extreme, reducing the reward for uncle blocks assists considerably with being able to forecast the true upper bound of the total ETC that will ultimately exist in the system. 
 
-* The model is the best attempt at balancing the needs to incentivize high risk investment into the system in order to bootstrap security and create a potential user base, be easy to understand, include a reduction to the rate of production of ETC over time, include an upper bound on supply, and also provide for a long term production of the ETC token.
+* The model is the best attempt at balancing the needs to incentivize high risk investment into the system in order to bootstrap security and create a potential user base, be easy to understand, include a reduction to the rate of production of ETC over time, include an upper bound on supply, provide for a long term production of the ETC token, and allow enough time for development, adoption, and awareness. 
 
 <br />
 


### PR DESCRIPTION
The "Maintenance" section of 1017 is unenforceable by code. Future generations of network users cannot be held to binding provisions set forth by the current generation of users unless agreed upon by those future users, and only by code. The decision to remove the section from the Proposal, as opposed to simply moving it to an appendix for reference, is to maintain focus of the proposal and to reduce the potential for confusion by readers, users, and developers.

Also, some minor grammar and clarity edits. 