### PR TITLE
ECIP-1021: Typo, missing space

### DIFF
--- a/ECIPs/ECIP-1021.md
+++ b/ECIPs/ECIP-1021.md
@@ -1,4 +1,4 @@
-##Title
+## Title
 
     ECIP: 1021
     Title: Token standard


### PR DESCRIPTION
`##Title` -> `## Title`. The former would not render correctly as a section for markdown.