### PR TITLE
ECIP-1021: add it to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The [ECIP sample](./ECIP-0000.md.sample) is the best place to start. The sample 
 | [ECIP-1010](ECIPs/ECIP-1010.md) | Delay Difficulty Bomb Explosion | Igor Artamonov | Standard | Consensus (hard-fork) | [Accepted](https://github.com/ethereumproject/ECIPs/issues/4) |
 | [ECIP-1013](ECIPs/ECIP-1013.md) | ETC On-Chain Cryptographic Signing and Authentication Protocol | Cody W Burns | Standard | Meta | Draft |
 | [ECIP-1017](ECIPs/ECIP-1017.md) | Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule | Matthew Mazur | Standard | Consensus (hard-fork) | Final |
-| [ECIP-1021](ECIPs/ECIP-1021.md) | Token Standard ERC23 | Dexaran | Standard | Contract | Draft |
+| [ECIP-1021](ECIPs/ECIP-1021.md) | Token Standard ERC23 | Dexaran | Standard | ERC | Draft |
 
 # EIPs that applies to Ethereum Classic network
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The [ECIP sample](./ECIP-0000.md.sample) is the best place to start. The sample 
 | [ECIP-1010](ECIPs/ECIP-1010.md) | Delay Difficulty Bomb Explosion | Igor Artamonov | Standard | Consensus (hard-fork) | [Accepted](https://github.com/ethereumproject/ECIPs/issues/4) |
 | [ECIP-1013](ECIPs/ECIP-1013.md) | ETC On-Chain Cryptographic Signing and Authentication Protocol | Cody W Burns | Standard | Meta | Draft |
 | [ECIP-1017](ECIPs/ECIP-1017.md) | Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule | Matthew Mazur | Standard | Consensus (hard-fork) | Final |
+| [ECIP-1021](ECIPs/ECIP-1021.md) | Token Standard ERC23 | Dexaran | Standard | Contract | Draft |
 
 # EIPs that applies to Ethereum Classic network
 


### PR DESCRIPTION
([Rendered](https://github.com/ethereumproject/ECIPs/tree/ecip-1021/add-to-readme))

Add ECIP-1021 to README, as it's not yet there.