### PR TITLE
ECIP-1023: Combined CarbonVote and MinerVote for Consensus Soft and Hard Forks

### DIFF
--- a/ECIPs/ECIP-1023.md
+++ b/ECIPs/ECIP-1023.md
@@ -1,0 +1,75 @@
+## Title
+
+    ECIP: 1023
+    Title: Combined CarbonVote and MinerVote for Consensus Soft and Hard Forks
+    Author: Wei Tang <hi@that.world>
+    Status: Draft
+    Type: Informational
+    Created: 2017/06/28
+    
+## Abstract
+
+The following ECIP tries to combine a enforced version of Ethereum CarbonVote and the best practices about how Bitcoin deals with consensus hard fork ([BIP-9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) and [BIP-135](https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki)) into Ethereum Classic using smart contracts. Rather than hard-code a block number as we currently do, each miner and ETC coin holders emits support of the new consensus hard-fork. Only when a large enough portion of the network support it, the hard-fork is "locked-in" and will be activated.
+
+This should be used in combination with ECIP-1022 for its best effect.
+
+## Motivation
+
+In addition to the motivation provided in ECIP-1022:
+
+**ETC coin holders are important**. Holders of coins should also have sayings about whether a hard fork should occur. CarbonVote, if it can be enforced, is a good way to do this.
+
+**Minimal cost for miners to emit support**. The cost for miners to emit support should be minimal.
+
+## Specification
+
+### Fork deployment parameters
+
+In addition to the fork deployment parameters defined in ECIP-1022, the following should also exist:
+
+* The **carbonThreshold** specifies the portion * 1000 required, in the entire start..(start + timeout) blocks, which should vote YES.
+
+### Carbon Vote
+
+Besides defining the signaling bits for miners to vote, the implementor of the hard fork should also deploy two new smart contracts (YES and NO) to the ETC network with the code below:
+
+```
+contract Vote {
+    string name;
+    uint start;
+    uint timeout;
+    uint carbonThreshold;
+    uint minerThreshold;
+    uint minLockedBlocks;
+
+    event LogVote(address indexed addr);
+
+    function() {
+        if (block.number < start || block.number >= start + timeout) {
+            throw;
+        }
+    
+        LogVote(msg.sender);
+
+        if (msg.value > 0) {
+            msg.sender.send(msg.value);
+        }
+    }
+}
+```
+
+ETC holders can vote YES and NO by sending a zero value transaction to any of those contracts.
+
+### Miner vote
+
+The miner will use the voting method defined in ECIP-1022 to conduct the voting.
+
+### Deployment states
+
+To make the voting pass (i.e. status changing from **STARTED** to **LOCKED_IN**), at each voting window, besides requiring the threshold out of windowsize blocks to have the associated bit set in `signalingBits` in `extraData` block header, it also requires the portion of ETC coins that voted YES in the Carbon Vote smart contracts >= (carbonThreshold / 1000000).
+
+Before implementing a hard fork, the implementor should deploy a smart contract for voting (referred to as *The Contract*) to the ETC network that has the following properties.
+
+## Rationale
+
+Miners continue to use `signalingBits` in the `extraData` field to vote, as this is the way with minimal cost for them (and also does not require any protocol change). The consensus is reached jointly by miners and coin holders for a hard fork to pass.

--- a/ECIPs/ECIP-1023.md
+++ b/ECIPs/ECIP-1023.md
@@ -39,11 +39,7 @@ Besides defining the signaling bits for miners to vote, the implementor of the h
 contract Vote {
     event LogVote(address indexed addr);
 
-    function() {
-        if (block.number < start || block.number >= start + timeout) {
-            throw;
-        }
-    
+    function() {    
         LogVote(msg.sender);
 
         if (msg.value > 0) {

--- a/ECIPs/ECIP-1023.md
+++ b/ECIPs/ECIP-1023.md
@@ -27,7 +27,9 @@ In addition to the motivation provided in ECIP-1022:
 
 In addition to the fork deployment parameters defined in ECIP-1022, the following should also exist:
 
-* The **carbonThreshold** specifies the portion * 1000 required, in the entire start..(start + timeout) blocks, which should vote YES.
+* **carbonVoteYesAddress** the address for carbon vote YES.
+* **carbonVoteNoAddress** the address for carbon vote NO.
+* **carbonThreshold** specifies the portion * 1000 required, in the entire start..(start + timeout) blocks, which should vote YES.
 
 ### Carbon Vote
 
@@ -35,13 +37,6 @@ Besides defining the signaling bits for miners to vote, the implementor of the h
 
 ```
 contract Vote {
-    string name;
-    uint start;
-    uint timeout;
-    uint carbonThreshold;
-    uint minerThreshold;
-    uint minLockedBlocks;
-
     event LogVote(address indexed addr);
 
     function() {


### PR DESCRIPTION
([Rendered](https://github.com/ethereumproject/ECIPs/blob/ecip1023/init/ECIPs/ECIP-1023.md))

This is an upgrade of ECIP-1022, and tries to take the opinions of both miners and coin holders during a hard fork. For a hard fork to pass, in addition to miners voting to pass (as defined in ECIP-1022), it also requires that a sufficient portion of coin holders to vote YES using Carbon Vote.

## Motivation

In addition to the motivation provided in [ECIP-1022](https://github.com/ethereumproject/ECIPs/pull/62):

**ETC coin holders are important**. Holders of coins should also have sayings about whether a hard fork should occur. CarbonVote, if it can be enforced, is a good way to do this.

**Minimal cost for miners to emit support**. The cost for miners to emit support should be minimal.

## Implementation

See [ECIP-1022](https://github.com/ethereumproject/ECIPs/blob/ecip1022/init/ECIPs/ECIP-1022.md#specification) for how miners vote for a hard fork, and see [this ECIP rendered](https://github.com/ethereumproject/ECIPs/blob/ecip1023/init/ECIPs/ECIP-1023.md) for how coin holders vote using Carbon Vote. Basically, it requires both miner vote and carbon vote to pass for a hard fork to take effect.

Also note that unlike miner vote, carbon vote does not have the block window period. The coin holder vote is valid for the whole start..(start + timeout) range and the voting result is checked each time a window period ends.