### PR TITLE
ECIP-1029: Include Uncles in Total Difficulty Calculation

### DIFF
--- a/ECIPs/ECIP-1029.md
+++ b/ECIPs/ECIP-1029.md
@@ -24,6 +24,8 @@ Soft-forked clients support a new [Ethereum Wire Protocol](https://github.com/et
 
 Clients are recommended to continue to support older version number `62` and `63`. `62` and `63` should continue to use the old total difficulty calculation formula (`B_t = B'_t + B_d`) on or after `FORK_BLOCK`.
 
+Soft-forked clients should use version `70`'s total difficulty (with or without uniform tie breaking) for best chain selection.
+
 ### References
 
 * Sompolinsky, Yonatan, and Aviv Zohar. "Accelerating bitcoin’s transaction processing." Fast Money Grows on Trees, Not Chains (2013).

--- a/ECIPs/ECIP-1029.md
+++ b/ECIPs/ECIP-1029.md
@@ -1,0 +1,30 @@
+### Title
+
+    ECIP: 1029
+    Title: Include Uncles in Total Difficulty Calculation
+    Author: Wei Tang <hi@that.world>
+    Status: Draft
+    Type: Standard
+    Layer: Consensus (soft-fork)
+    Created: 2017-08-15
+    
+### Abstract
+
+This proposes to include uncle difficulty in total difficulty calcuation after `FORK_BLOCK`. New client will use a different [Ethereum Wire Protocol](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol) version number to broadcast the total difficulty calculated using the new formula. As a result, old clients will continue to function if soft-forked clients are the majority.
+    
+### Background
+
+Ethereum is advertised to use [GHOST protocol](https://eprint.iacr.org/2013/881.pdf) for best chain selection. The calculation is done using "total difficulty". The client will always select the chain with larger total difficulty. However, while uncles are included in blocks and miners are rewarded to include them, they do not participate in the calculation of total difficulty thus do not participate in the best chain selection. This deflicts the goal of GHOST protocol, which should always select the chain in which, including stale blocks, is the heaviest.
+
+Analysis by [Gervais et al.](https://eprint.iacr.org/2016/555.pdf) has shown that, due to the above fact, Ethereum currently resembles a similar Proof of Work algorithm as Bitcoin. Besides, due to its fast block time (around 10 seconds) and growing block size, it is having a much larger orphan rate compared with other Proof of Work cryptocurrencies like Bitcoin, Litcoin and Dogecoin.
+
+### Specification
+
+Soft-forked clients support a new [Ethereum Wire Protocol](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol) version number `70`. Before `FORK_BLOCK`, version `70` works the same as the current version `63`. On or after `FORK_BLOCK`, change the total difficulty calculation from `B_t = B'_t + B_d` to `B_t = B'_t + sum(B_U_d) + B_d`. That is, to also sum up difficulty of uncles included in the current block and add it to the total difficulty.
+
+Clients are recommended to continue to support older version number `62` and `63`. `62` and `63` should continue to use the old total difficulty calculation formula (`B_t = B'_t + B_d`) on or after `FORK_BLOCK`.
+
+### References
+
+* Sompolinsky, Yonatan, and Aviv Zohar. "Accelerating bitcoin’s transaction processing." Fast Money Grows on Trees, Not Chains (2013).
+* Gervais, Arthur, et al. "On the security and performance of proof of work blockchains." Proceedings of the 2016 ACM SIGSAC Conference on Computer and Communications Security. ACM, 2016.


### PR DESCRIPTION
([Rendered](https://github.com/ethereumproject/ECIPs/blob/ecip-1029/ECIPs/ECIP-1029.md))

### Abstract

This proposes to include uncle difficulty in total difficulty calcuation after `FORK_BLOCK`. New client will use a different [Ethereum Wire Protocol](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol) version number to broadcast the total difficulty calculated using the new formula. As a result, old clients will continue to function if soft-forked clients are the majority.
    
### Background

Ethereum is advertised to use [GHOST protocol](https://eprint.iacr.org/2013/881.pdf) for best chain selection. The calculation is done using "total difficulty". The client will always select the chain with larger total difficulty. However, while uncles are included in blocks and miners are rewarded to include them, they do not participate in the calculation of total difficulty thus do not participate in the best chain selection. This deflicts the goal of GHOST protocol, which should always select the chain in which, including stale blocks, is the heaviest.

Analysis by [Gervais et al.](https://eprint.iacr.org/2016/555.pdf) has shown that, due to the above fact, Ethereum currently resembles a similar Proof of Work algorithm as Bitcoin. Besides, due to its fast block time (around 10 seconds) and growing block size, it is having a much larger orphan rate compared with other Proof of Work cryptocurrencies like Bitcoin, Litcoin and Dogecoin.