### PR TITLE
Add missing ECIPs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The [ECIP sample](./ECIP-1.sample.md) is the best place to start. The sample was
 | [ECIP-1010](ECIPs/ECIP-1010.md) | Delay Difficulty Bomb Explosion | Igor Artamonov | Standard | Consensus (hard-fork) | [Accepted](https://github.com/ethereumproject/ECIPs/issues/4) |
 | [ECIP-1013](ECIPs/ECIP-1013.md) | ETC On-Chain Cryptographic Signing and Authentication Protocol | Cody W Burns | Standard | Meta | Draft |
 | [ECIP-1017](ECIPs/ECIP-1017.md) | Monetary Policy and Final Modification to the Ethereum Classic Emission Schedule | Matthew Mazur | Standard | Consensus (hard-fork) | Final |
+| [ECIP-1021](ECIPs/ECIP-1021.md) | ERC223 Token Standard | Dexaran | Standard | ERC | Draft |
+| [ECIP-1030](ECIPs/ECIP-1030.md) | Defining the SYSTEM Transaction | Wei Tang | Standard | Meta | Draft |
 
 # EIPs that applies to Ethereum Classic network
 


### PR DESCRIPTION
ECIP-1021 and ECIP-1030 was in the ECIP folder but not in the README file.