### PR TITLE
ECIP-1031: Recursive Length Prefix Media Type

### DIFF
--- a/ECIPs/ECIP-1031.md
+++ b/ECIPs/ECIP-1031.md
@@ -1,0 +1,29 @@
+### Title
+
+    ECIP: 1031
+    Title: Recursive Length Prefix Media Types
+    Author: Wei Tang <hi@that.world>
+    Status: Draft
+    Type: Standard
+    Layer: Meta
+    Created: 2017-08-29
+    
+### Abstract
+
+Recursive Length Prefix (see [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B) is the data type used for all common Ethereum Classic structures including blocks, raw transactions, receipts and accounts. Defining a media type for Recursive Length Prefix (RLP) would allow a RESTful HTTP server to return raw RLP information directly.
+
+### Specification
+
+Define a new media type according to RFC6838 under `application.vnd.ecip.rlp`. This media type has no required or optional parameters. It uses binary encoding. The specification for RLP can be found at [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B.
+
+### Example
+
+*Note this section is only served as an example of how this media type might be used, and is not part of the specification.*
+
+A client can implement a RESTful API that returns RLP binary data directly. We use the routes below, that partially implements the functionality of the current JSON RPC protocol.
+
+* `GET /{0xhex or number or latest or pending}`: returns RLP binary data of a given block.
+* `GET /{0xhex or number or latest or pending}/transactions/{0xhex or number}`: returns RLP binary data of a transaction.
+* `GET /{0xhex or number or latest or pending}/receipts/{0xhex or number}`: returns RLP binary data of a transaction receipt.
+* `PUT /pending/transactions`: accepts a raw RLP transaction input, and put it into the transaction mempool.
+* `GET /{0xhex or number or latest or pending}/accounts/{0xhex}`: returns the RLP binary data of an account.

--- a/ECIPs/ECIP-1031.md
+++ b/ECIPs/ECIP-1031.md
@@ -1,7 +1,7 @@
 ### Title
 
     ECIP: 1031
-    Title: Recursive Length Prefix Media Types
+    Title: Recursive Length Prefix Media Type
     Author: Wei Tang <hi@that.world>
     Status: Draft
     Type: Standard

--- a/ECIPs/ECIP-1031.md
+++ b/ECIPs/ECIP-1031.md
@@ -10,11 +10,11 @@
     
 ### Abstract
 
-Recursive Length Prefix (see [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B) is the data type used for all common Ethereum Classic structures including blocks, raw transactions, receipts and accounts. Defining a media type for Recursive Length Prefix (RLP) would allow a RESTful HTTP server to return raw RLP information directly.
+Recursive Length Prefix (see [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B) is the data type used for all common Ethereum Classic structures including blocks, raw transactions, receipts and accounts. Defining a media type for Recursive Length Prefix (RLP) would allow a RESTful HTTP server to return raw RLP information directly. This is more efficient than the current JSON format for RPC calls.
 
 ### Specification
 
-Define a new media type according to RFC6838 under `application.vnd.ecip.rlp`. This media type has no required or optional parameters. It uses binary encoding. The specification for RLP can be found at [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B.
+Define a new media type according to RFC6838 under `application/vnd.ecip.rlp`. This media type has no required or optional parameters. It uses binary encoding. The specification for RLP can be found at [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B.
 
 ### Example
 

--- a/ECIPs/ECIP-1031.md
+++ b/ECIPs/ECIP-1031.md
@@ -14,7 +14,7 @@ Recursive Length Prefix (see [Yellow Paper](https://ethereum.github.io/yellowpap
 
 ### Specification
 
-Define a new media type according to RFC6838 under `application/vnd.ecip.rlp`. This media type has no required or optional parameters. It uses binary encoding. The specification for RLP can be found at [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B.
+Define a new media type according to RFC6838 under `application/vnd.ecip.rlp` ([IANA media type assignment](https://www.iana.org/assignments/media-types/application/vnd.ecip.rlp)). This media type has no required or optional parameters. It uses binary encoding. The specification for RLP can be found at [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B.
 
 ### Example
 


### PR DESCRIPTION
([Rendered](https://github.com/ethereumproject/ECIPs/blob/ecip1031/ECIPs/ECIP-1031.md))

### Abstract

Recursive Length Prefix (see [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) Appendix B) is the data type used for all common Ethereum Classic structures including blocks, raw transactions, receipts and accounts. Defining a media type for Recursive Length Prefix (RLP) would allow a RESTful HTTP server to return raw RLP information directly.