### PR TITLE
ECIP-1036: Fallback Complete Difficulty Bomb Diffusion

### DIFF
--- a/ECIPs/ECIP-1036.md
+++ b/ECIPs/ECIP-1036.md
@@ -16,7 +16,7 @@ This ECIP describes a fallback plan if an extension of ECIP-1010 does not activa
 
 There is currently a small probability that [an extension of ECIP-1010](https://github.com/ethereumproject/ECIPs/issues/63) might not be able to be activated. The probability is really slight, but it is still possible. Please see the discussion of that issue for reasonings from different parties. This ECIP provides a fallback plan, to give assurance for those who might be impantient or worried of the difficulty bomb, so as to avoid a possible community split or an unexcepted hard fork.
 
-Block 5452163 is chosen as the fork block number. This is a totally arbitrary and meaningless number. In this way, we avoid collisions of the fork block number with other protocol improvement hard forks.
+Block 5452163 is chosen as the fork block number. This is a totally arbitrary and meaningless number. In this way, we avoid collisions of the fork block number with other protocol upgrade hard forks.
 
 ### Specification
 

--- a/ECIPs/ECIP-1036.md
+++ b/ECIPs/ECIP-1036.md
@@ -20,7 +20,7 @@ Block 5452163 is chosen as the fork block number. This is a totally arbitrary an
 
 ### Specification
 
-At block 5452163, change the difficulty calculation formula to:
+If [an extension of ECIP-1010](https://github.com/ethereumproject/ECIPs/issues/63) is rejected, at block 5452163, change the difficulty calculation formula to:
 
 ```
 block_diff = parent_diff 

--- a/ECIPs/ECIP-1036.md
+++ b/ECIPs/ECIP-1036.md
@@ -1,0 +1,30 @@
+### Title
+
+    ECIP: 1036
+    Title: Fallback Complete Difficulty Bomb Diffusion
+    Author: Wei Tang <hi@that.world>
+    Status: Draft
+    Type: Standard
+    Layer: Consensus
+    Created: 2017-09-06
+    
+### Abstract
+
+This ECIP describes a fallback plan if an extension of ECIP-1010 does not activate. If that is the case, then completely diffuse the difficulty bomb at block 5452163.
+    
+### Motivation
+
+There is currently a small probability that [an extension of ECIP-1010](https://github.com/ethereumproject/ECIPs/issues/63) might not be able to be activated. The probability is really slight, but it is still possible. Please see the discussion of that issue for reasonings from different parties. This ECIP provides a fallback plan, to give assurance for those who might be impantient or worried of the difficulty bomb, so as to avoid a possible community split or an unexcepted hard fork.
+
+Block 5452163 is chosen as the fork block number. This is a totally arbitrary and meaningless number. In this way, we avoid collisions of the fork block number with other protocol improvement hard forks.
+
+### Specification
+
+At block 5452163, change the difficulty calculation formula to:
+
+```
+block_diff = parent_diff 
+     + parent_diff / 2048 * max(1 - (block_timestamp - parent_timestamp) / 10, -99) 
+```
+
+That is, remove the `int(2**explosion)` part from the formula in ECIP-1010.


### PR DESCRIPTION
([Rendered](https://github.com/ethereumproject/ECIPs/blob/ecip-1036/ECIPs/ECIP-1036.md))

### Abstract

This ECIP describes a fallback plan if an extension of ECIP-1010 does not activate. If that is the case, then completely diffuse the difficulty bomb at block 5452163.
    
### Motivation

There is currently a small probability that [an extension of ECIP-1010](https://github.com/ethereumproject/ECIPs/issues/63) might not be able to be activated. The probability is really slight, but it is still possible. Please see the discussion of that issue for reasonings from different parties. This ECIP provides a fallback plan, to give assurance for those who might be impantient or worried of the difficulty bomb, so as to avoid a possible community split or an unexcepted hard fork.

Block 5452163 is chosen as the fork block number. This is a totally arbitrary and meaningless number. In this way, we avoid collisions of the fork block number with other protocol upgrade hard forks.
