### PR TITLE
Fix ECIP1010 difficulty values

### DIFF
--- a/ECIPs/ECIP-1010.md
+++ b/ECIPs/ECIP-1010.md
@@ -90,8 +90,8 @@ With this changes min difficulty value will become:
 * Block 3,000,000 == 2**28 == 268,435,456
 * Block 4,000,000 == 2**28 == 268,435,456
 * Block 5,000,000 == 2**28 == 268,435,456
-* Block 5,200,000 == 2**30 == 1 TH
-* Block 6,000,000 == 2**38 == 274 TH
+* Block 5,200,000 == 2**30 == 1 GH
+* Block 6,000,000 == 2**38 == 274 GH
 
 ### Links
 * Difficulty growth model: https://docs.google.com/spreadsheets/d/1ZXNrSCNV0HGWU7zOTUyIIRUGv5M44P6wiAZclpY4Y2Q/edit 


### PR DESCRIPTION
Fix a typo `TH` -> `GH`.

`2**30` is 1GH and `2**38` is 274GH.