### PR TITLE
ECIP-1044: Formalize IPFS hash into ECNS resolver

### DIFF
--- a/ECIPs/ECIP-1044.md
+++ b/ECIPs/ECIP-1044.md
@@ -1,0 +1,84 @@
+### Title
+
+    ECIP: 1044
+    Title: Formalize IPFS hash into ECNS(Ethereum Classic Name Service) resolver
+    Author: Phyrex Tsai <phyrex@portal.network>, Portal Network Team
+    Status: Draft
+    Type: ERC
+    Created: 2018-05-12
+
+# ECIP 1044 - Formalize IPFS hash into ECNS(Ethereum Classic Name Service) resolver
+
+## Simple Summary
+To specify the mapping protocol between resources stored on IPFS and ECNS(Ethereum Classic Name Service).
+
+## Abstract
+The following standard details the implementation of how to combine the IPFS cryptographic hash unique fingerprint with ecns public resolver. This standard provides a functionality to get and set IPFS online resources to ecns resolver.
+  
+We think that this implementation is not only aim to let more developers and communities to provide more use cases, but also leverage the human-readable features to gain more user adoption accessing decentralized resources. We considered the IPFS ecns resolver mapping standard a cornerstone for building future Web3.0 service.
+
+## Motivation
+To build fully decentralized web service, it’s necessary to have a decentralized file storage system. Here comes the IPFS, for three following advantages :
+- Address large amounts of data, and has unique cryptographic hash for every record.
+- Since IPFS is also based on peer to peer network, it can be really helpful to deliver large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
+- IPFS stores files in high efficient way via tracking version history for every file, and removing the duplications across the network.
+  
+Those features makes perfect match for integrating into ecns, and these make users can easily access content through ecns, and show up in the normal browser.
+
+
+## Specification
+The condition now is that the IPFS file fingerprint using base58 and in the meantime, the Ethereum Classic uses hex in API to encode the binary data. So that need a way to process the condition requires not only we need to transfer from IPFS to Ethereum Classic, but also need to convert it back.
+  
+To solve these requirements, we can use binary buffer bridging that gap.  
+When mapping the IPFS base58 string to ecns resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ecns, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
+
+
+## Rationale
+To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
+  
+```
+function setMultihash(bytes32 node, bytes hash) public only_owner(node);
+```
+  
+Whenever users need to visit the ecns content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+  
+```
+function multihash(bytes32 node) public view returns (bytes);
+```
+
+## Test Cases
+
+To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.  
+The library link : [https://www.npmjs.com/package/multihashes](https://www.npmjs.com/package/multihashes)  
+To implement the method transfer from IPFS(Base58) to hex format :
+  
+```
+import multihash from 'multihashes'
+
+export const toHex = function(ipfsHash) {
+  let buf = multihash.fromB58String(ipfsHash);
+  return '0x' + multihash.toHexString(buf);
+}
+```
+  
+To implement the method transfer from hex format to IPFS(Base58) :
+  
+```
+import multihash from 'multihashes'
+
+export const toBase58 = function(contentHash) {
+  let hex = contentHash.substring(2)
+  let buf = multihash.fromHexString(hex);
+  return multihash.toB58String(buf);
+}
+```
+
+## Implementation
+The use case can be implemented as browser extension. Users can easily download the extension, and easily get decentralized resources by just typing the ECNS just like we normally type the DNS to browser the website. Solve the current pain for normal people can not easily visit the total decentralized website.
+
+The workable implementation repository : [https://github.com/PortalNetwork/portal-network-browser-extension](https://github.com/PortalNetwork/portal-network-browser-extension)
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+

--- a/ECIPs/ECIP-1044.md
+++ b/ECIPs/ECIP-1044.md
@@ -34,16 +34,16 @@ When mapping the IPFS base58 string to ecns resolver, first we convert the Base5
 
 
 ## Rationale
-To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
+To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setContent` method below :
   
 ```
-function setMultihash(bytes32 node, bytes hash) public only_owner(node);
+function setContent(bytes32 node, bytes32 hash) public only_owner(node);
 ```
   
-Whenever users need to visit the ecns content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+Whenever users need to visit the ecns content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
-function multihash(bytes32 node) public view returns (bytes);
+function content(bytes32 node) public view returns (bytes);
 ```
 
 ## Test Cases

--- a/ECIPs/ECIP-1044.md
+++ b/ECIPs/ECIP-1044.md
@@ -34,16 +34,16 @@ When mapping the IPFS base58 string to ecns resolver, first we convert the Base5
 
 
 ## Rationale
-To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setContent` method below :
+To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
   
 ```
-function setContent(bytes32 node, bytes32 hash) public only_owner(node);
+function setMultihash(bytes32 node, bytes hash) public only_owner(node);
 ```
   
-Whenever users need to visit the ecns content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+Whenever users need to visit the ecns content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
-function content(bytes32 node) public view returns (bytes);
+function multihash(bytes32 node) public view returns (bytes);
 ```
 
 ## Test Cases


### PR DESCRIPTION
### Title

    ECIP: 1044
    Title: Formalize IPFS hash into ECNS resolver
    Author: Phyrex Tsai <phyrex@portal.network>, Portal Network Team
    Status: Draft
    Type: ERC
    Created: 2018-05-12

# ECIP 1044 - Formalize IPFS hash into ECNS(Ethereum Classic Name Service) resolver

## Simple Summary
To specify the mapping protocol between resources stored on IPFS and ECNS(Ethereum Classic Name Service).

## Abstract
The following standard details the implementation of how to combine the IPFS cryptographic hash unique fingerprint with ecns public resolver. This standard provides a functionality to get and set IPFS online resources to ecns resolver.
  
We think that this implementation is not only aim to let more developers and communities to provide more use cases, but also leverage the human-readable features to gain more user adoption accessing decentralized resources. We considered the IPFS ecns resolver mapping standard a cornerstone for building future Web3.0 service.

## Motivation
To build fully decentralized web service, it’s necessary to have a decentralized file storage system. Here comes the IPFS, for three following advantages :
- Address large amounts of data, and has unique cryptographic hash for every record.
- Since IPFS is also based on peer to peer network, it can be really helpful to deliver large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
- IPFS stores files in high efficient way via tracking version history for every file, and removing the duplications across the network.
  
Those features makes perfect match for integrating into ecns, and these make users can easily access content through ecns, and show up in the normal browser.


## Specification
The condition now is that the IPFS file fingerprint using base58 and in the meantime, the Ethereum Classic uses hex in API to encode the binary data. So that need a way to process the condition requires not only we need to transfer from IPFS to Ethereum Classic, but also need to convert it back.
  
To solve these requirements, we can use binary buffer bridging that gap.  
When mapping the IPFS base58 string to ecns resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ecns, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.


## Rationale
To implement the specification, need two methods from ecns public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
  
```
function setMultihash(bytes32 node, bytes hash) public only_owner(node);
```
  
Whenever users need to visit the ecns content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
  
```
function multihash(bytes32 node) public view returns (bytes);
```

## Test Cases

To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.  
The library link : [https://www.npmjs.com/package/multihashes](https://www.npmjs.com/package/multihashes)  
To implement the method transfer from IPFS(Base58) to hex format :
  
```
import multihash from 'multihashes'

export const toHex = function(ipfsHash) {
  let buf = multihash.fromB58String(ipfsHash);
  return '0x' + multihash.toHexString(buf);
}
```
  
To implement the method transfer from hex format to IPFS(Base58) :
  
```
import multihash from 'multihashes'

export const toBase58 = function(contentHash) {
  let hex = contentHash.substring(2)
  let buf = multihash.fromHexString(hex);
  return multihash.toB58String(buf);
}
```

## Implementation
The use case can be implemented as browser extension. Users can easily download the extension, and easily get decentralized resources by just typing the ECNS just like we normally type the DNS to browser the website. Solve the current pain for normal people can not easily visit the total decentralized website.

The workable implementation repository : [https://github.com/PortalNetwork/portal-network-browser-extension](https://github.com/PortalNetwork/portal-network-browser-extension)

## Copyright
Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


